### PR TITLE
task points langfix

### DIFF
--- a/common/format.typ
+++ b/common/format.typ
@@ -1,6 +1,6 @@
 #let format-date(date, language) = if type(date) != datetime {
   date
-} else if language == "ger" {
+} else if language == "de" {
   date.display("[day].[month repr:numerical].[year]")
 } else {
   date.display("[month repr:long] [day], [year]")

--- a/common/thesis_statement_pursuant.typ
+++ b/common/thesis_statement_pursuant.typ
@@ -37,7 +37,7 @@
       align: horizon,
       [
         #location,
-        #format-date(date, "ger")
+        #format-date(date, "de")
       ],
       align(right)[
         #stack(

--- a/common/tudapub_title_page.typ
+++ b/common/tudapub_title_page.typ
@@ -17,7 +17,7 @@
   accentcolor: "9c",
 
   // language for correct hyphenation
-  language: "eng",
+  language: "en",
 
 
   // author name as text, e.g "Albert Author"

--- a/example_tudapub.typ
+++ b/example_tudapub.typ
@@ -342,7 +342,7 @@ In the following, we show the show-command of this template with all doc and def
   reviewer_names: ("SuperSupervisor 1", "SuperSupervisor 2"),
 
   // language for correct hyphenation
-  language: "eng",
+  language: "en",
 
   // Set the margins of the content pages.
   // The title page is not affected by this.

--- a/templates/tudaexercise/template/locales.typ
+++ b/templates/tudaexercise/template/locales.typ
@@ -1,5 +1,5 @@
 #let dict_de = (
-  locale: "ger",
+  locale: "de",
   task: "Aufgabe",
 
   sheet: "Übungsblatt",
@@ -14,7 +14,7 @@
 )
 
 #let dict_en = (
-  locale: "eng",
+  locale: "en",
   task: "Task",
 
   sheet: "Sheet",
@@ -28,16 +28,19 @@
   date: "Due"
 )
 
+#let dicts = (
+  de: dict_de,
+  en: dict_en,
+)
+
 /// Returns the dictionary for the given locale.
 ///
-/// - locale (str): The locale to get the dictionary for, can be "ger" or "eng".
+/// - locale (str): The locale to get the dictionary for, can be "de" or "en".
 /// -> Returns: The dictionary for the given locale.
 #let get-locale-dict(locale) = {
-  if locale == "ger" {
-    dict_de
-  } else if locale == "eng" {
-    dict_en
-  } else {
+  let dict = dicts.at(locale, default: none)
+  if dict == none {
     panic("Unsupported locale: " + locale)
   }
+  dict
 }

--- a/templates/tudaexercise/template/locales.typ
+++ b/templates/tudaexercise/template/locales.typ
@@ -40,7 +40,7 @@
 #let get-locale-dict(locale) = {
   let dict = dicts.at(locale, default: none)
   if dict == none {
-    panic("Unsupported locale: " + locale)
+    panic("Unsupported locale: " + locale + ". Supported locales are: " + dicts.keys().join(", ", last: " and "))
   }
   dict
 }

--- a/templates/tudaexercise/template/tudaexercise.typ
+++ b/templates/tudaexercise/template/tudaexercise.typ
@@ -23,7 +23,7 @@
 /// #show: tudaexercise.with(<options>)
 /// ```
 /// 
-/// - language ("eng", "ger"): The language for dates and certain keywords
+/// - language ("en", "de"): The language for dates and certain keywords
 /// 
 /// - margins (dictionary): The page margins, possible entries: `top`, `left`,
 ///   `bottom`, `right`
@@ -70,7 +70,7 @@
 /// 
 /// - body (content): 
 #let tudaexercise(
-  language: "eng",
+  language: "en",
 
   margins: tud_exercise_page_margin,
 
@@ -207,7 +207,8 @@
     kerning: true,
     ligatures: false,
     spacing: 91%, // to make it look like the latex template,
-    fill: text_color
+    fill: text_color,
+    lang: language,
   )
 
   let dict = get-locale-dict(language)
@@ -340,7 +341,7 @@
   let ctxpoints-name-single = points-name-single
   let ctxpoints-name-plural = points-name-plural
   if (points-name-single == auto or points-name-plural == auto) {
-    let dict = get-locale-dict(s.get().language)
+    let dict = get-locale-dict(text.lang)
     if (points-name-single == auto) {
       ctxpoints-name-single = dict.point_singular
     }
@@ -378,7 +379,7 @@
 ) = context {
   let ctxdifficulty-name = difficulty-name
   if(difficulty-name == auto) {
-    ctxdifficulty-name = get-locale-dict(s.get().language).difficulty
+    ctxdifficulty-name = get-locale-dict(text.lang).difficulty
   }
   if(ctxdifficulty-name != none) {
     ctxdifficulty-name + difficulty-sep

--- a/templates/tudapub/template/tudapub.typ
+++ b/templates/tudapub/template/tudapub.typ
@@ -47,7 +47,7 @@
   reviewer_names: ("SuperSupervisor 1", "SuperSupervisor 2"),
 
   // language for correct hyphenation
-  language: "eng",
+  language: "en",
 
   // Set the margins of the content pages.
   // The title page is not affected by this.

--- a/templates_examples/tudaexercise/main.typ
+++ b/templates_examples/tudaexercise/main.typ
@@ -96,7 +96,7 @@ If you do not like lines around subtasks you can pass `subtask: "plain"` to not 
 = More options
 
 The leftover options are:
-- `language` to control the language of certain keywords (can either be `"ger"` or `"eng"`)
+- `language` to control the language of certain keywords (can either be `"de"` or `"en"`)
 - `margins` which is a dictionary controlling the page margins
 - `paper` which currently only supports `"a4"`
 - `headline` which currently is unsupported.

--- a/templates_examples/tudaexercise/main.typ
+++ b/templates_examples/tudaexercise/main.typ
@@ -3,7 +3,7 @@
 )
 
 #show: tudaexercise.with(
-  language: "eng",
+  language: "en",
   info: (
     title: "Usage of TUDaExercise",
     subtitle: "A small guide.",

--- a/tests/tudaexercise/test_tudaexercise.typ
+++ b/tests/tudaexercise/test_tudaexercise.typ
@@ -17,7 +17,7 @@
     author: "Albert Author",
     sheet: 5,
   ),
-  language: "eng",
+  language: "en",
   design: (
     accentcolor: "9c",
   ),

--- a/tests/tudapub/test_tudapub.typ
+++ b/tests/tudapub/test_tudapub.typ
@@ -23,7 +23,7 @@
   ],
   author: "Albert Author",
   accentcolor: "9c",
-  language: "eng",
+  language: "en",
 
 
   abstract: [The abstract...],


### PR DESCRIPTION
Replaces state based language with the default `lang` functionality of text, using the typst defined languages instead of "ger" and "eng"